### PR TITLE
Minor changes to add GitHub Actions support

### DIFF
--- a/lib/Devel/Cover/Report/Kritika.pm
+++ b/lib/Devel/Cover/Report/Kritika.pm
@@ -101,6 +101,7 @@ sub _detect_revision {
         qw/
         TRAVIS_COMMIT
         CI_BUILD_REF
+        GITHUB_SHA
         /
       )
     {
@@ -226,6 +227,8 @@ It will detect the following services:
 =item * L<Travis CI|https://travis-ci.org/>
 
 =item * L<GitLab|https://about.gitlab.com/gitlab-ci/>
+
+=item * L<GitHub Actions|https://docs.github.com/en/actions>
 
 =back
 


### PR DESCRIPTION
Add the environment variable that [GitHub Actions use](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables) and a note that it is detected.

My current work around is
```yaml
 - name: Coverage Reporting
   run: cover -test -report kritika
   env:
     KRITIKA_TOKEN: ${{ secrets.KRITIKA_TOKEN }}
     CI_BUILD_REF: ${{ github.sha }}
```